### PR TITLE
ci: add CI change filter

### DIFF
--- a/.github/workflows/plugin_test.yaml
+++ b/.github/workflows/plugin_test.yaml
@@ -34,13 +34,13 @@ jobs:
         with:
           filters: |
             # e2e_file path: plugin path 
-            gear/test/gear_plugin_test.yaml: gear
-            gin/v2/test/gin_plugin_test.yaml: gin/v2
-            gin/v3/test/gin_plugin_test.yaml: gin/v3
-            go-restful/test/go_restful_plugin_test.yaml: go-restful
-            micro/test/go_micro_plugin_test.yaml: micro
-            resty/test/go_resty_plugin_test.yaml: resty
-            kratos/test/go_kratos_plugin_test.yaml: kratos
+            gear/test/gear_plugin_test.yaml: gear/**
+            gin/v2/test/gin_plugin_test.yaml: gin/v2/**
+            gin/v3/test/gin_plugin_test.yaml: gin/v3/**
+            go-restful/test/go_restful_plugin_test.yaml: go-restful/**
+            micro/test/go_micro_plugin_test.yaml: micro/**
+            resty/test/go_resty_plugin_test.yaml: resty/**
+            kratos/test/go_kratos_plugin_test.yaml: kratos/**
 
   PluginsTest:
     name: Plugin

--- a/.github/workflows/plugin_test.yaml
+++ b/.github/workflows/plugin_test.yaml
@@ -40,6 +40,7 @@ jobs:
             micro/test/go_micro_plugin_test.yaml: micro/**
             resty/test/go_resty_plugin_test.yaml: resty/**
             kratos/test/go_kratos_plugin_test.yaml: kratos/**
+            sql/test/sql_plugin_test.yaml: sql/**
 
   PluginsTest:
     name: Plugin

--- a/.github/workflows/plugin_test.yaml
+++ b/.github/workflows/plugin_test.yaml
@@ -23,21 +23,32 @@ on:
       - master
 
 jobs:
+  Changes:
+    runs-on: ubuntu-latest
+    outputs:
+      e2e_file: ${{ steps.filter.outputs.changes }}
+    steps:
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            gear/test/gear_plugin_test.yaml: gear
+            gin/v2/test/gin_plugin_test.yaml: gin/v2
+            gin/v3/test/gin_plugin_test.yaml: gin/v3
+            go-restful/test/go_restful_plugin_test.yaml: go-restful
+            micro/test/go_micro_plugin_test.yaml: micro
+            resty/test/go_resty_plugin_test.yaml: resty
+            kratos/test/go_kratos_plugin_test.yaml: kratos
+
   PluginsTest:
     name: Plugin
+    needs: Changes
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        case:
-          - { name: 'Gear', e2e_file: 'gear/test/gear_plugin_test.yaml' }
-          - { name: 'Gin v2', e2e_file: 'gin/v2/test/gin_plugin_test.yaml' }
-          - { name: 'Gin v3', e2e_file: 'gin/v3/test/gin_plugin_test.yaml' }
-          - { name: 'Go Restful', e2e_file: 'go-restful/test/go_restful_plugin_test.yaml' }
-          - { name: 'Go Micro', e2e_file: 'micro/test/go_micro_plugin_test.yaml' }
-          - { name: 'Go Resty', e2e_file: 'resty/test/go_resty_plugin_test.yaml' }
-          - { name: 'Go Kratos', e2e_file: 'kratos/test/go_kratos_plugin_test.yaml'}
+        e2e_file: ${{ fromJSON(needs.Changes.outputs.e2e_file) }}
     steps:
       - uses: actions/checkout@v2
       - uses: apache/skywalking-infra-e2e@main
         with:
-          e2e-file: ${{ matrix.case.e2e_file }}
+          e2e-file: ${{ matrix.e2e_file }}

--- a/.github/workflows/plugin_test.yaml
+++ b/.github/workflows/plugin_test.yaml
@@ -21,6 +21,7 @@ on:
   push:
     branches:
       - master
+      - main
 
 jobs:
   Changes:
@@ -32,6 +33,7 @@ jobs:
         id: filter
         with:
           filters: |
+            # e2e_file path: plugin path 
             gear/test/gear_plugin_test.yaml: gear
             gin/v2/test/gin_plugin_test.yaml: gin/v2
             gin/v3/test/gin_plugin_test.yaml: gin/v3

--- a/.github/workflows/plugin_test.yaml
+++ b/.github/workflows/plugin_test.yaml
@@ -21,7 +21,6 @@ on:
   push:
     branches:
       - master
-      - main
 
 jobs:
   Changes:


### PR DESCRIPTION
Plugin E2E test is very time consuming and not always needed for those not changed, we can only run E2E test for changed plugin by applying a filter 

The effect can be seen here https://github.com/kagaya85/go2sky-plugins/pull/3